### PR TITLE
Amanda/switch to stripe generated products

### DIFF
--- a/app/assets/javascripts/checkout.js
+++ b/app/assets/javascripts/checkout.js
@@ -16,9 +16,15 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!response.ok) {
         // Handle HTTP errors (e.g., 404, 500)
         console.error('HTTP error:', response.status);
-        return response.text().then(text => { //Get the text of the error page.
+        return response.text().then(text => { 
+          //Get the text of the error page.
           console.error('Error details:', text);
-          throw new Error(`HTTP error! status: ${response.status}`);
+          if (response.status === 500 ) {
+            console.error('Server encountered an internal error.');
+            alert('An unexpected server error occured. Please try again later.');
+          } else {
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
         });
       }
       // Check the content type
@@ -26,7 +32,8 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!contentType || !contentType.includes('application/json')) {
         // Handle non-JSON responses
         console.error('Not a JSON response');
-        return response.text().then(text => { //Get the text of the error page.
+        return response.text().then(text => { 
+          //Get the text of the error page.
           console.error('Response details:', text);
           throw new Error('Not a JSON response!');
         });
@@ -45,7 +52,7 @@ document.addEventListener('DOMContentLoaded', function () {
       shippingAddressElement.mount('#address-element-shipping');
       billingAddressElement.mount('#address-element-billing');
       paymentElement.mount('#payment-element');
-      
+      // FIXME - add EL to a button...? step 7 of accept a payment docs 
       form.addEventListener('submit', function (event) {
         event.preventDefault();
     

--- a/app/assets/javascripts/checkout.js
+++ b/app/assets/javascripts/checkout.js
@@ -52,7 +52,6 @@ document.addEventListener('DOMContentLoaded', function () {
       shippingAddressElement.mount('#address-element-shipping');
       billingAddressElement.mount('#address-element-billing');
       paymentElement.mount('#payment-element');
-      // FIXME - add EL to a button...? step 7 of accept a payment docs 
       form.addEventListener('submit', function (event) {
         event.preventDefault();
     

--- a/app/assets/javascripts/checkout.js
+++ b/app/assets/javascripts/checkout.js
@@ -27,18 +27,6 @@ document.addEventListener('DOMContentLoaded', function () {
           }
         });
       }
-      // Check the content type
-      const contentType = response.headers.get('content-type');
-      if (!contentType || !contentType.includes('application/json')) {
-        // Handle non-JSON responses
-        console.error('Not a JSON response');
-        return response.text().then(text => { 
-          //Get the text of the error page.
-          console.error('Response details:', text);
-          throw new Error('Not a JSON response!');
-        });
-      }
-      //If everything is ok, parse to JSON
       return response.json();
     })
     .then((data) => {

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -7,7 +7,7 @@ class CartItemsController < ApplicationController
 
   def create
     @cart = Current.cart
-    @product = product_setup
+    product_setup
     @quantity = params[:cart_item][:quantity].to_i
 
     @new_cart_item = CartService::AddToCart.call(product: @product, 
@@ -49,7 +49,7 @@ class CartItemsController < ApplicationController
       @products = Stripe::Product.list(active: true, limit: 100).map do |product|
                     ProductWrapper.new(product)
                   end
-      @product = @products.find { |item| item.id === (params[:cart_item][:stripe_product_id]) }
+      @product = @products.find { |item| item.id == params[:cart_item][:stripe_product_id] }
     end
 
     def cart_item_params 

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -1,7 +1,6 @@
 class CheckoutsController < ApplicationController
   def new
     cart_and_total_setup
-    @transaction_total_in_dollars = @total / 100.00
   end
   
   def create

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -27,15 +27,6 @@ class CheckoutsController < ApplicationController
     @total = CartService::CalculateCart.call(cart: @cart)
   end
 
-  def line_items_setup
-    line_items = @cart.cart_items.map do |item|
-      {
-        price: item.price,
-        quantity: item.quantity
-      }
-    end
-  end
-
   def set_payment_intent(cart)
     @existing_intent = Checkout.find_by(
       cart_id: cart.id, 
@@ -60,11 +51,9 @@ class CheckoutsController < ApplicationController
       end
 
       unless @payment_intent.amount == @total
-        line_items_setup
         Stripe::PaymentIntent.update(
           @payment_intent.id, 
           amount: @total,
-          line_items: line_items,
         )
       end
 

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -7,7 +7,14 @@ class CheckoutsController < ApplicationController
   def create
     @cart = Current.cart
     @payment_intent = set_payment_intent(@cart)
-    
+
+    line_items = @cart.cart_items.map do |item|
+      {
+        price: item.product.stripe_price_id,
+        quantity: item.quantity
+      }
+    end
+
     checkout = Checkout.create(
       payment_intent_id: @payment_intent.id,
       cart_id: @cart.id,
@@ -51,6 +58,7 @@ class CheckoutsController < ApplicationController
         Stripe::PaymentIntent.update(
           @payment_intent.id, 
           amount: @total
+          line_items: line_items
         )
       end
 
@@ -65,7 +73,8 @@ class CheckoutsController < ApplicationController
       amount: @total,
       currency: 'usd',
       automatic_payment_methods: { enabled: true },
-      metadata: { cart_id: @cart.id }      
+      metadata: { cart_id: @cart.id },
+      line_items: line_items # for my reference; not used by Stripe directly  
     })
   end
 end

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -8,13 +8,6 @@ class CheckoutsController < ApplicationController
     cart_and_total_setup
     @payment_intent = set_payment_intent(@cart)
 
-    line_items = @cart.cart_items.map do |item|
-                 {
-                   price: item.price,
-                   quantity: item.quantity
-                 }
-    end
-
     checkout = Checkout.create(
       payment_intent_id: @payment_intent.id,
       cart_id: @cart.id,

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,10 @@
 class ProductsController < ApplicationController
   before_action :set_product, only: %i[ show ]
   def index
-    @products = Product.all
+    # implement a bg job to migrate these periodically
+    @products = Stripe::Product.list(active: true, limit: 100).map do |product|
+                  ProductWrapper.new(product)
+                end
   end
 
   def show

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,17 +1,21 @@
 class ProductsController < ApplicationController
+  before_action :call_stripe_products, only: %i[ index show ]
   before_action :set_product, only: %i[ show ]
+
   def index
-    # implement a bg job to migrate these periodically
-    @products = Stripe::Product.list(active: true, limit: 100).map do |product|
-                  ProductWrapper.new(product)
-                end
   end
 
   def show
   end
 
   private
+    def call_stripe_products
+      @products = Stripe::Product.list(active: true, limit: 100).map do |product|
+        ProductWrapper.new(product)
+      end
+    end
+  
     def set_product
-      @product = Product.find(params.expect(:id))
+      @product = @products.find { |product| product.id === params[:id] }
     end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -16,6 +16,6 @@ class ProductsController < ApplicationController
     end
   
     def set_product
-      @product = @products.find { |product| product.id === params[:id] }
+      @product = @products.find { |product| product.id == params[:id] }
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def to_dollars(item_price)
+    number_to_currency((item_price / 100).round(2))
+  end
 end

--- a/app/lib/product_wrapper.rb
+++ b/app/lib/product_wrapper.rb
@@ -1,0 +1,14 @@
+class ProductWrapper < SimpleDelegator
+  def price
+    product = __getobj__
+    price = (Stripe::Price.retrieve(product.default_price)
+                          .unit_amount) / 100.00
+  end
+
+  # slug? instead of product id
+
+  # DB - denormalize and add relevant fields into cart_items before you drop Products table
+end
+
+# ProductWrapper.new(StripeProduct.new)
+

--- a/app/lib/product_wrapper.rb
+++ b/app/lib/product_wrapper.rb
@@ -1,14 +1,13 @@
 class ProductWrapper < SimpleDelegator
+  # in cents; for calculations & Stripe transaction logic
   def price
     product = __getobj__
     price = (Stripe::Price.retrieve(product.default_price)
-                          .unit_amount) / 100.00
+                          .unit_amount)
   end
 
-  # slug? instead of product id
-
-  # DB - denormalize and add relevant fields into cart_items before you drop Products table
+  # for view display of pricing only
+  def price_in_dollars
+    price = self.price / 100
+  end
 end
-
-# ProductWrapper.new(StripeProduct.new)
-

--- a/app/lib/product_wrapper.rb
+++ b/app/lib/product_wrapper.rb
@@ -1,13 +1,12 @@
 class ProductWrapper < SimpleDelegator
   # in cents; for calculations & Stripe transaction logic
   def price
-    product = __getobj__
-    price = (Stripe::Price.retrieve(product.default_price)
-                          .unit_amount)
+    Stripe::Price.retrieve(self.default_price)
+                 .unit_amount
   end
 
   # for view display of pricing only
   def price_in_dollars
-    price = self.price / 100
+    price / 100
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -2,8 +2,7 @@ class Cart < ApplicationRecord
   has_many :cart_items, dependent: :destroy
   validates :session_id, presence: true, uniqueness: true
 
-  def total_in_dollars
-    @total = CartService::CalculateCart.call(cart: self)
-    @total / 100
+  def total
+    CartService::CalculateCart.call(cart: self)
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,4 +1,9 @@
 class Cart < ApplicationRecord
   has_many :cart_items, dependent: :destroy
   validates :session_id, presence: true, uniqueness: true
+
+  def total_in_dollars
+    @total = CartService::CalculateCart.call(cart: self)
+    @total / 100
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,13 +1,4 @@
 class Cart < ApplicationRecord
   has_many :cart_items, dependent: :destroy
   validates :session_id, presence: true, uniqueness: true
-
-  def add_product(product)
-    cart_item = cart_items.build(product: product)
-    cart_item.price = product.price # had to set this explicitly, not sure if cleaner way to write
-    if cart_item.price.present?
-      self.total_amount += cart_item.price
-    end
-    cart_item
-  end
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,7 +1,6 @@
 class CartItem < ApplicationRecord
   belongs_to :cart
-  belongs_to :product
-  validates :product_id, uniqueness: { scope: :cart_id }
+  validates :stripe_product_id, uniqueness: { scope: :cart_id }
   before_validation :set_quantity
   before_validation :set_price
 
@@ -13,6 +12,7 @@ class CartItem < ApplicationRecord
     end
   end
   def set_price
+    # FIXME - this method needs to be updated for Stripe paradigm
     self.price ||= product.price if product.present?
   end
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -16,14 +16,12 @@ class CartItem < ApplicationRecord
     end
   end
 
-  # REVIEW - is there a way to do this without an API call?
   def set_price
     @products = Stripe::Product.list(active: true, limit: 100).map do |product|
       ProductWrapper.new(product)
     end
 
-    related_product = @products.find { |product| product.id === self.stripe_product_id }
-
+    related_product = Stripe::Product.retrieve(self.stripe_product_id)
     self.price ||= related_product.price if related_product.present?
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,3 @@
 class Product < ApplicationRecord
   belongs_to :product_category
-  has_many :cart_items
 end

--- a/app/services/cart_service/add_to_cart.rb
+++ b/app/services/cart_service/add_to_cart.rb
@@ -8,14 +8,16 @@ module CartService
 
     def self.check_for_duplicate_cart_items(product:, cart:, quantity:)
       cart_items = cart.cart_items.to_a
-      existing_item = cart_items.find { |item| item.product_id == product.id }
+      existing_item = cart_items.find { |i| i.stripe_product_id == product.id }
       if existing_item
         existing_item.quantity += quantity
         existing_item.tap(&:save!)
       else
         new_cart_item = CartItem.create!(price: product.price,
                                          cart_id: cart.id,
-                                         product_id: product.id,
+                                         stripe_product_id: product.id,
+                                         image: product.images[0],
+                                         name: product.name,
                                          quantity: quantity)
         cart.cart_items.reload
         new_cart_item

--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -1,7 +1,7 @@
 <div>
   <% @cart.cart_items.each do |item| %>
-    <%= item.product.name %>
-    <%= item.product.price %>
+    <%= item.name.titleize %>
+    <p>Price: <%= number_to_currency(item.price_in_dollars) %></p>
     <p>Quantity: <%= item.quantity %></p>
     <%= button_to 'remove item', 
         cart_item_path(item.id), 
@@ -9,5 +9,5 @@
         class: 'text-red-400 text-sm font-bold' %>
   <% end %>
 
-  <p>Total: <%= @total %> </p>
+  <p>Total: <%= number_to_currency(@cart.total_in_dollars) %> </p>
 </div>

--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -1,7 +1,7 @@
 <div>
   <% @cart.cart_items.each do |item| %>
     <%= item.name.titleize %>
-    <p>Price: <%= number_to_currency(item.price_in_dollars) %></p>
+    <p>Price: <%= to_dollars(item.price) %></p>
     <p>Quantity: <%= item.quantity %></p>
     <%= button_to 'remove item', 
         cart_item_path(item.id), 
@@ -9,5 +9,5 @@
         class: 'text-red-400 text-sm font-bold' %>
   <% end %>
 
-  <p>Total: <%= number_to_currency(@cart.total_in_dollars) %> </p>
+  <p>Total: <%= to_dollars(@cart.total) %> </p>
 </div>

--- a/app/views/checkouts/new.html.erb
+++ b/app/views/checkouts/new.html.erb
@@ -1,4 +1,4 @@
-<p><%= number_to_currency(@transaction_total_in_dollars) %> due.</p>
+<p><%= to_dollars(@total) %> due.</p>
 <form id="payment-form" 
   data-stripe-publishable-key="<%= Rails.application
                                         .credentials

--- a/app/views/checkouts/new.html.erb
+++ b/app/views/checkouts/new.html.erb
@@ -1,11 +1,10 @@
-<p><%= @total %> due.</p>
+<p><%= number_to_currency(@transaction_total_in_dollars) %> due.</p>
 <form id="payment-form" 
   data-stripe-publishable-key="<%= Rails.application
                                         .credentials
                                         .dig(:stripe, :publishable_key) %>"
   data-checkout-success-path="<%= checkout_success_url %>">
   <div id="payment-element">
-    <!--Stripe.js injects Payment Element Here-->
   </div>
   <div id="address-element-shipping">
   </div>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,12 +1,13 @@
 <div class="bg-green-200 p-5">
-  <p><%= link_to "#{product.name}", product_path(product.id) %></p>
+  <p><%= link_to "#{product.name.titleize}", product_path(product.id) %></p>
   <% product.images.each do |i| %>
     <%= image_tag("#{i}",
                   width: 200) %>
   <% end %>
-  <%= number_to_currency(product.price) %>
+  <p>Price: <%= number_to_currency(product.price_in_dollars) %></p>
+
   <%= form_for :cart_item, url: cart_items_path, method: :post do |f| %>
-    <%= hidden_field_tag 'cart_item[product_id]', product.id %>
+    <%= hidden_field_tag 'cart_item[stripe_product_id]', product.id %>
     <%= f.label :quantity %>: 
     <%= f.number_field :quantity, 
       class:'bg-yellow-200',

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,7 +1,9 @@
 <div class="bg-green-200 p-5">
   <p><%= link_to "#{product.name}", product_path(product.id) %></p>
-  <p>[image]</p>
-  <p><%= product.default_price %></p>
+  <% product.images.each do |i| %>
+    <%= image_tag("#{i}",
+                  width: 200) %>
+  <% end %>
   <%= number_to_currency(product.price) %>
   <%= form_for :cart_item, url: cart_items_path, method: :post do |f| %>
     <%= hidden_field_tag 'cart_item[product_id]', product.id %>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,10 +1,9 @@
 <div class="bg-green-200 p-5">
   <p><%= link_to "#{product.name.titleize}", product_path(product.id) %></p>
   <% product.images.each do |i| %>
-    <%= image_tag("#{i}",
-                  width: 200) %>
+    <%= image_tag(i, width: 200) %>
   <% end %>
-  <p>Price: <%= number_to_currency(product.price_in_dollars) %></p>
+  <p>Price: <%= to_dollars(product.price) %></p>
 
   <%= form_for :cart_item, url: cart_items_path, method: :post do |f| %>
     <%= hidden_field_tag 'cart_item[stripe_product_id]', product.id %>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,7 +1,8 @@
 <div class="bg-green-200 p-5">
-  <p><%= link_to "#{product.name}", product %></p>
+  <p><%= link_to "#{product.name}", product_path(product.id) %></p>
   <p>[image]</p>
-  <p><%= product.price %></p>
+  <p><%= product.default_price %></p>
+  <%= number_to_currency(product.price) %>
   <%= form_for :cart_item, url: cart_items_path, method: :post do |f| %>
     <%= hidden_field_tag 'cart_item[product_id]', product.id %>
     <%= f.label :quantity %>: 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -5,7 +5,7 @@
   <!--[this will be where ProductCategory lives; may use param filter strategy a la Henventory]-->
   <div class="flex flex-col gap-10">
     <% @products.each do |product| %>
-      <%= render product %>
+      <%= render partial: "product", object: product %>
     <% end %>
   </div>
 </div>

--- a/db/migrate/20250522165536_denormalize_cart_items.rb
+++ b/db/migrate/20250522165536_denormalize_cart_items.rb
@@ -1,0 +1,7 @@
+class DenormalizeCartItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :cart_items, :stripe_product_id, :text, null: false
+    add_column :cart_items, :name, :text, null: :false
+    add_column :cart_items, :image, :text, default: 'https://www.blastone.com/wp-content/uploads/image-coming-soon-29.png', null: :false
+  end
+end

--- a/db/migrate/20250522171317_remove_old_index_in_cart_items.rb
+++ b/db/migrate/20250522171317_remove_old_index_in_cart_items.rb
@@ -1,0 +1,5 @@
+class RemoveOldIndexInCartItems < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :cart_items, [:cart_id, :product_id], unique: true
+  end
+end

--- a/db/migrate/20250522171359_add_new_index_to_cart_items.rb
+++ b/db/migrate/20250522171359_add_new_index_to_cart_items.rb
@@ -1,0 +1,5 @@
+class AddNewIndexToCartItems < ActiveRecord::Migration[8.0]
+  def change
+    add_index :cart_items, [:cart_id, :stripe_product_id], unique: true
+  end
+end

--- a/db/migrate/20250522171527_remove_product_id_from_cart_items.rb
+++ b/db/migrate/20250522171527_remove_product_id_from_cart_items.rb
@@ -1,0 +1,5 @@
+class RemoveProductIdFromCartItems < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :cart_items, :product_id, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_15_212103) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_22_171527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "cart_items", force: :cascade do |t|
     t.integer "price", null: false
-    t.integer "product_id", null: false
     t.integer "cart_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "quantity", default: 1, null: false
-    t.index ["cart_id", "product_id"], name: "index_cart_items_on_cart_id_and_product_id", unique: true
+    t.text "stripe_product_id", null: false
+    t.text "name"
+    t.text "image", default: "https://www.blastone.com/wp-content/uploads/image-coming-soon-29.png"
+    t.index ["cart_id", "stripe_product_id"], name: "index_cart_items_on_cart_id_and_stripe_product_id", unique: true
   end
 
   create_table "carts", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,28 +7,33 @@ ProductCategory.delete_all
 product_category = ProductCategory.create!(name: "Essential Oils Test Category")
 
 Product.create!(
-  name: 'Blue Tansy', 
-  price: 30, 
+  name: 'Melissa', 
+  price: 1800, 
   product_category_id: product_category.id
 )
 Product.create!(
-  name: 'Rose',
-  price: 95,
+  name: 'Sage',
+  price: 900,
   product_category_id: product_category.id
 )
 Product.create!(
-  name: 'Spike Lavender',
-  price: 20,
+  name: 'Immortelle',
+  price: 2000,
   product_category_id: product_category.id
 )
 Product.create!(
-  name: 'Birch',
-  price: 15,
+  name: 'Roman Chamomile',
+  price: 1500,
   product_category_id: product_category.id
 )
 Product.create!(
-  name: 'Orange',
-  price: 15,
+  name: 'Hyssop',
+  price: 1100,
+  product_category_id: product_category.id
+)
+Product.create!(
+  name: 'Lavender',
+  price: 1000,
   product_category_id: product_category.id
 )
 puts "#{Product.count} products created"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,32 +9,44 @@ product_category = ProductCategory.create!(name: "Essential Oils Test Category")
 Product.create!(
   name: 'Melissa', 
   price: 1800, 
-  product_category_id: product_category.id
+  product_category_id: product_category.id,
+  stripe_price_id: 'price_1RKACrC2evWDh2V2MlDwc5z7',
+  stripe_product_id: 'prod_SEdTk1bZbKa6a1'
 )
 Product.create!(
   name: 'Sage',
   price: 900,
-  product_category_id: product_category.id
+  product_category_id: product_category.id,
+  stripe_price_id: 'price_1RKAB0C2evWDh2V2OVPut3p7',
+  stripe_product_id: 'prod_SEdRAILBQj1iOb'
 )
 Product.create!(
   name: 'Immortelle',
   price: 2000,
-  product_category_id: product_category.id
+  product_category_id: product_category.id,
+  stripe_price_id: 'price_1RK5efC2evWDh2V2lkvdqQB2',
+  stripe_product_id: 'prod_SEYmDAzbEBHtC5'
 )
 Product.create!(
   name: 'Roman Chamomile',
   price: 1500,
-  product_category_id: product_category.id
+  product_category_id: product_category.id,
+  stripe_price_id: 'price_1RK5cIC2evWDh2V2kvNl4dFV',
+  stripe_product_id: 'prod_SEYjnKbDeuvVQW'
 )
 Product.create!(
   name: 'Hyssop',
   price: 1100,
-  product_category_id: product_category.id
+  product_category_id: product_category.id,
+  stripe_price_id: 'price_1RK5fSC2evWDh2V21BNqbarM',
+  stripe_product_id: 'prod_SEYinuRcBDegmN'
 )
 Product.create!(
   name: 'Lavender',
   price: 1000,
-  product_category_id: product_category.id
+  product_category_id: product_category.id,
+  stripe_price_id: 'price_1RJKDAC2evWDh2V2p8E2Uo8W',
+  stripe_product_id: 'prod_SDljakyHifZra3'
 )
 puts "#{Product.count} products created"
 


### PR DESCRIPTION
## **work on 🌿 `amanda/switch-to-stripe-generated-products`:**
_________________________________
### `checkout.js`
- adjusting format/indentation of some comments
- refining error handling for checkout creation
_________________________________
### Controllers
- `CartItemsController` - privatizing / abstracting definition of `@products` via API call & setting of `@product`
- `CheckoutsController` - abstracting repetitive definitions of `@cart`, `line_items`, and `@total`; defining `@transaction_total_in_dollars` for view usage
- `ProductsController` - setting `before_action` to complete Stripe Product Inventory API call; refactoring `set_product` action to use Stripe Product id
_________________________________
### new delegator - `ProductWrapper`
- creating `ProductWrapper` to create a simple `price` method to extract price-in-cents from Stripe Product object when creating `CartItem`s
  - also wrote a `price_in_dollars` method to be used in product views only (`#index`, `#show`)
_________________________________
### Models
- removing `add_product` method from `Cart` model since `AddToCart` service now handles this business logic
- writing a `total_in_dollars` method within `Cart` model to be used in cart view for user-friendly display

- breaking ActiveRecord relationship between `CartItem` and `Product` models & tables
  - rewriting validation on CartItem to look for unique combinations between `stripe_product_id` and `cart_id` (instead of between `product_id` and `cart_id` as before)

- rewriting `set_price` validation on `CartItem` to use Stripe products 
_________________________________
### Service Objects
- revising `AddToCart` to use Stripe Product attributes (id, image URL, name, etc).
_________________________________
### Views
- adjusting `_cart` and `checkouts/new` views to use `number_to_currency` helper for totals-in-dollars

- adjusting `_product` partial to use stripe product id for cart item params in hidden field
  - adjusting the syntax for rendering this partial within `products/index` now that it's not using an ActiveRecord object 
_________________________________
### Schema
- denormalizing `cart_items` table in preparation for deprecation of `products` table
  - adding `stripe_product_id`, `name`, and `image` columns with non-null constraints and default values as needed
  - revising indexing to use `stripe_product_id` instead of `product_id`
  - removing `product_id` column


_________________________________

❗ Have not dropped `Product` and `ProductCategory` table yet - wanted to make sure this PR looked good before I did that
❗ Have not cleared `seeds.rb` for same reason

_________________________________
## 🔜 Future Considerations
- writing a background job to periodically migrate Stripe Products into `@products` collection
- caching product information to avoid repeated API calls
- using `expandable` attribute of Stripe Product Object to eliminate API call to Stripe Price objects
- writing slugs for `products/show` for cleaner UX