### PR TITLE
Amanda/post checkout hard deletion of cart

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -2,12 +2,11 @@ class CartItemsController < ApplicationController
   before_action :set_cart_item, only: %i[ destroy ]
 
   def create
-    cart = Current.cart
     product_setup
     quantity = params[:cart_item][:quantity].to_i
 
     @new_cart_item = CartService::AddToCart.call(product: @product, 
-                                                 cart: cart, 
+                                                 cart: @cart, 
                                                  quantity: @quantity)
 
     respond_to do |format|

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,11 +1,9 @@
 class CartsController < ApplicationController
   def show
-    @cart = Current.cart
     @total = CartService::CalculateCart.call(cart: @cart)
   end
 
   def update
-    @cart = Current.cart
     respond_to do |format|
       if @cart.update(cart_params)
         format.html { redirect_to @cart, notice: "Bag was updated!" }

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -47,6 +47,7 @@ class CheckoutsController < ApplicationController
 
     if @session.status == 'complete'
       redirect_to checkout_success_url
+      @cart.destroy!
       # handle successful payment
       # update db
       # send confirmation email

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -1,11 +1,9 @@
 class CheckoutsController < ApplicationController
   def new
-    @cart = Current.cart
     @total = CartService::CalculateCart.call(cart: @cart)
   end
   
   def create
-    @cart = Current.cart
     line_items = @cart.cart_items.map do |item|
       product = Stripe::Product.retrieve(
         { id: item.stripe_product_id, expand: ['default_price'] }


### PR DESCRIPTION
❗ this is based off changes made on #5 , so it may be helpful to review this PR after that one.
🐜 this is a very small PR but wanted to get this logic put in ASAP after our conversation today about blocking issues being priority 1
________________
## **work on 🌿`amanda/post-checkout-hard-deletion-of-cart`:**
- adding simple deletion of the current cart when a Stripe Checkout Session & its Payment Intent succeed
  - this will act as a placeholder until I can build the `CartCleanup` service to soft-delete records and run a job to hard-delete records after 30 days
- also removing redundant definitions of `@cart` since that variable is being set globally in `ApplicationController`  